### PR TITLE
Type hinting fixes

### DIFF
--- a/neware_api/neware.py
+++ b/neware_api/neware.py
@@ -50,10 +50,11 @@ def _xml_to_records(
         result.append(el_dict)
     return [{k: _auto_convert_type(v) for k, v in el.items()} for el in result]
 
+
 def _xml_to_lists(
     xml_string: str,
     list_name: str = "list",
-) -> dict[str,list]:
+) -> dict[str, list]:
     """Extract elements inside <list> tags, convert to a dictionary of lists.
 
     Args:
@@ -65,10 +66,11 @@ def _xml_to_lists(
             like 'orient = list' in JSON
 
     """
-    result = _xml_to_records(xml_string,list_name)
+    result = _xml_to_records(xml_string, list_name)
     return _lod_to_dol(result)
 
-def _lod_to_dol(ld: list[dict]) -> dict[str,list]:
+
+def _lod_to_dol(ld: list[dict]) -> dict[str, list]:
     """Convert list of dictionaries to dictionary of lists."""
     return {k: [d[k] for d in ld] for k in ld[0]}
 
@@ -86,7 +88,7 @@ class NewareAPI:
         self.ip = ip
         self.port = port
         self.neware_socket = socket.socket()
-        self.channel_map: dict[str,dict] = {}
+        self.channel_map: dict[str, dict] = {}
         self.start_message = '<?xml version="1.0" encoding="UTF-8" ?><bts version="1.0">'
         self.end_message = "</bts>"
         self.termination = "\n\n#\r\n"
@@ -249,7 +251,7 @@ class NewareAPI:
 
         return _xml_to_records(xml_string)
 
-    def download_data(self, pipeline: str) -> dict[str,list]:
+    def download_data(self, pipeline: str) -> dict[str, list]:
         """Download the data points for chlid.
 
         Uses the channel map to get the device id, subdevice id, and channel id.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,8 +39,8 @@ neware = "neware_api.cli.main:app"
 
 [tool.ruff]
 line-length = 120  # Set the maximum line length
-select = ["ALL"]
-ignore = [
+lint.select = ["ALL"]
+lint.ignore = [
     "N806",
     "T201",
     "FA102",
@@ -50,6 +50,9 @@ ignore = [
     "PLR2004",
     "TD002",
     "TD003",
+    "D203",
+    "D213",
+    "COM812",
 ]
 fix = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,3 +52,6 @@ ignore = [
     "TD003",
 ]
 fix = true
+
+[tool.mypy]
+disable_error_code = ["import-untyped"]


### PR DESCRIPTION
Fixed some type hinting errors

Split `_extract_from_xml` into two functions (instead of having multiple return types):
- `_xml_to_records` parses and returns list of dicts
- `_xml_to_lists` parses and returns dict of lists, assuming all records have the same keys