### PR TITLE
Status function

### DIFF
--- a/neware_api/cli/main.py
+++ b/neware_api/cli/main.py
@@ -1,6 +1,11 @@
 """CLI for the Neware battery cycling API."""
 
+import json
+from typing import Annotated, Optional
+
 import typer
+
+from neware_api import NewareAPI
 
 app = typer.Typer()
 
@@ -12,9 +17,26 @@ def start() -> None:
 
 
 @app.command()
-def status() -> None:
-    """Get the status of the cycling process."""
-    typer.echo("Getting the status of the cycling process is NOT IMPLEMENTED YET.")
+def status(pipeline_ids: Annotated[Optional[list[str]], typer.Argument()] = None) -> None:  # noqa: UP007
+    """Get the status of the cycling process for all or selected pipelines.
+
+    Example usage:
+    >>> neware status
+    {"13-1-1": {"ip":127.0.0.1, "devtype": 27 ... }, "13-1-2": { ... }, ...
+    >>> neware status 13-1-5
+    {"13-1-5":{...}}
+    >>> neware status 13-1-5 14-3-5
+    {"13-1-5":{...}, "14-3-5":{...}}
+
+    Args:
+        pipeline_ids (optional, list[str]): list of pipeline IDs to get status from
+
+    Raises:
+        KeyError if pipeline ID not in channel map
+
+    """
+    with NewareAPI() as nw:
+        typer.echo(json.dumps(nw.get_status(pipeline_ids)))
 
 
 if __name__ == "__main__":

--- a/neware_api/cli/main.py
+++ b/neware_api/cli/main.py
@@ -29,7 +29,8 @@ def status(pipeline_ids: Annotated[Optional[list[str]], typer.Argument()] = None
     {"13-1-5":{...}, "14-3-5":{...}}
 
     Args:
-        pipeline_ids (optional, list[str]): list of pipeline IDs to get status from
+        pipeline_ids (optional): list of pipeline IDs to get status from
+            will use the full channel map if not provided
 
     Raises:
         KeyError if pipeline ID not in channel map

--- a/neware_api/cli/main.py
+++ b/neware_api/cli/main.py
@@ -36,7 +36,7 @@ def status(pipeline_ids: Annotated[Optional[list[str]], typer.Argument()] = None
 
     """
     with NewareAPI() as nw:
-        typer.echo(json.dumps(nw.get_status(pipeline_ids)))
+        typer.echo(json.dumps(nw.inquire_channel(pipeline_ids)))
 
 
 if __name__ == "__main__":

--- a/neware_api/neware.py
+++ b/neware_api/neware.py
@@ -204,7 +204,7 @@ class NewareAPI:
             pipelines = self.channel_map
         if isinstance(pipeline_ids, str):
             pipelines = {pipeline_ids: self.channel_map[pipeline_ids]}
-        if isinstance(pipeline_ids, list):
+        elif isinstance(pipeline_ids, list):
             pipelines = {p: self.channel_map[p] for p in pipeline_ids}
 
         # Create and submit command XML string
@@ -249,7 +249,7 @@ class NewareAPI:
             pipelines = self.channel_map
         if isinstance(pipeline_ids, str):
             pipelines = {pipeline_ids: self.channel_map[pipeline_ids]}
-        if isinstance(pipeline_ids, list):
+        elif isinstance(pipeline_ids, list):
             pipelines = {p: self.channel_map[p] for p in pipeline_ids}
 
         # Create and submit command XML string

--- a/neware_api/neware.py
+++ b/neware_api/neware.py
@@ -185,7 +185,7 @@ class NewareAPI:
         footer = "</list>"
         return self.command(header + cmd_string + footer)
 
-    def get_status(self, pipeline_ids: str | list[str] | None = None) -> dict[str,dict]:
+    def get_status(self, pipeline_ids: str | list[str] | None = None) -> dict[str, dict]:
         """Get status of pipeline(s).
 
         Args:
@@ -204,7 +204,7 @@ class NewareAPI:
             pipelines = self.channel_map
         if isinstance(pipeline_ids, str):
             pipelines = {pipeline_ids: self.channel_map[pipeline_ids]}
-        if isinstance(pipeline_ids,list):
+        if isinstance(pipeline_ids, list):
             pipelines = {p: self.channel_map[p] for p in pipeline_ids}
 
         # Create and submit command XML string

--- a/neware_api/neware.py
+++ b/neware_api/neware.py
@@ -29,12 +29,11 @@ def _xml_to_records(
     """Extract elements inside <list> tags, convert to a list of dictionaries.
 
     Args:
-        xml_string (str): raw xml string
-        list_name (str): the tag that contains the list of elements to parse
+        xml_string: raw xml string
+        list_name: the tag that contains the list of elements to parse
 
     Returns:
-        list[dict]: a list of dictionaries
-            like 'orient = records' in JSON
+        list of dictionaries like 'orient = records' in JSON
 
     """
     # Parse response XML string
@@ -58,11 +57,11 @@ def _xml_to_lists(
     """Extract elements inside <list> tags, convert to a dictionary of lists.
 
     Args:
-        xml_string (str): raw xml string
-        list_name (str): the tag that contains the list of elements to parse
+        xml_string: raw xml string
+        list_name: the tag that contains the list of elements to parse
 
     Returns:
-        dict[str,list]: keys are the names of records, each has a list of values
+        dict where keys are the names of records, each has a list of values
             like 'orient = list' in JSON
 
     """
@@ -189,11 +188,11 @@ class NewareAPI:
         """Get status of pipeline(s).
 
         Args:
-            pipeline_ids (str|list[str], optional): pipeline ID or list of pipeline IDs
+            pipeline_ids (optional): pipeline ID or list of pipeline IDs
                 if not given, all pipelines from channel map are used
 
         Returns:
-            list[dict]: a dictionary per channel with status
+            a dictionary per channel with status
 
         Raises:
             KeyError: if pipeline ID not in the channel map
@@ -236,11 +235,11 @@ class NewareAPI:
         time, and whether the channel is currently open.
 
         Args:
-            pipeline_ids (optional, str|list[str]): pipeline IDs or list of pipeline Ids
+            pipeline_ids (optional): pipeline IDs or list of pipeline Ids
                 default: None, will get all pipeline IDs in the channel map
 
         Returns:
-            dict[str,dict]: a dictionary per channel with the latest info and data point
+            a dictionary per channel with the latest info and data point
                 key is the pipeline ID e.g. "13-1-5"
 
         """
@@ -296,7 +295,7 @@ class NewareAPI:
         """Get device information.
 
         Returns:
-            list[dict]: IP, device type, device id, sub-device id and channel id of all channels
+            IP, device type, device id, sub-device id and channel id of all channels
 
         """
         command = "<cmd>getdevinfo</cmd>"

--- a/neware_api/neware.py
+++ b/neware_api/neware.py
@@ -264,7 +264,7 @@ class NewareAPI:
         footer = "</list>"
         xml_string = self.command(header + middle + footer)
 
-        records =  _xml_to_records(xml_string)
+        records = _xml_to_records(xml_string)
 
         return {
             pipeline_id: {**record, **pipeline_dict}


### PR DESCRIPTION
`get_status` returns dict of dicts
e.g. `{"13-1-1": {"ip": "127.0.0.1", "devtype": "27", "status": "working"}` etc.

Command line interface works with or without arguments

`neware status` returns status of all channels

`neware status 13-1-5` returns status of machine 13 sub-device 1 channel 5 (I call this pipeline 13-1-5 consistent with tomato)

`neware status 13-1-5 13-2-6` returns status of multiple pipelines

NOTE: I think we do not get the barcode of the sample on the pipeline, which would be nice. I'll investigate if this is possible later.